### PR TITLE
hw2: adding locators to dropdown menu items

### DIFF
--- a/app/commands/actions.html
+++ b/app/commands/actions.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li class="active"><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions" class="active"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/aliasing.html
+++ b/app/commands/aliasing.html
@@ -31,23 +31,23 @@
           <li class="dropdown">
             <a class="active" href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li class="active"><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing" class="active"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/assertions.html
+++ b/app/commands/assertions.html
@@ -41,31 +41,23 @@
                 >Commands <span class="caret"></span
               ></a>
               <ul class="dropdown-menu">
-                <li><a href="/commands/querying">Querying</a></li>
-                <li><a href="/commands/traversal">Traversal</a></li>
-                <li><a href="/commands/actions">Actions</a></li>
-                <li><a href="/commands/window">Window</a></li>
-                <li><a href="/commands/viewport">Viewport</a></li>
-                <li><a href="/commands/location">Location</a></li>
-                <li><a href="/commands/navigation">Navigation</a></li>
-                <li class="active">
-                  <a href="/commands/assertions">Assertions</a>
-                </li>
-                <li><a href="/commands/misc">Misc</a></li>
-                <li><a href="/commands/connectors">Connectors</a></li>
-                <li><a href="/commands/aliasing">Aliasing</a></li>
-                <li><a href="/commands/waiting">Waiting</a></li>
-                <li>
-                  <a href="/commands/network-requests">Network Requests</a>
-                </li>
-                <li><a href="/commands/files">Files</a></li>
-                <li><a href="/commands/local-storage">Local Storage</a></li>
-                <li><a href="/commands/cookies">Cookies</a></li>
-                <li>
-                  <a href="/commands/spies-stubs-clocks"
-                    >Spies, Stubs &amp; Clocks</a
-                  >
-                </li>
+                <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+                <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+                <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+                <li data-test="Window"><a href="/commands/window">Window</a></li>
+                <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+                <li data-test="Location"><a href="/commands/location">Location</a></li>
+                <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+                <li data-test="Assertions" class="active"><a href="/commands/assertions">Assertions</a></li>
+                <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+                <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+                <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+                <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+                <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+                <li data-test="Files"><a href="/commands/files">Files</a></li>
+                <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+                <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+                <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
               </ul>
             </li>
             <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/connectors.html
+++ b/app/commands/connectors.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li class="active"><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors" class="active"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/cookies.html
+++ b/app/commands/cookies.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li class="active"><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies" class="active"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/files.html
+++ b/app/commands/files.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li class="active"><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files" class="active"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/local-storage.html
+++ b/app/commands/local-storage.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li class="active"><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage" class="active"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/location.html
+++ b/app/commands/location.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li class="active"><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location" class="active"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/misc.html
+++ b/app/commands/misc.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li class="active"><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc" class="active"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/navigation.html
+++ b/app/commands/navigation.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li class="active"><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation" class="active"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/network-requests.html
+++ b/app/commands/network-requests.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li class="active"><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests" class="active"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/querying.html
+++ b/app/commands/querying.html
@@ -41,31 +41,23 @@
                 >Commands <span class="caret"></span
               ></a>
               <ul class="dropdown-menu">
-                <li class="active">
-                  <a href="/commands/querying">Querying</a>
-                </li>
-                <li><a href="/commands/traversal">Traversal</a></li>
-                <li><a href="/commands/actions">Actions</a></li>
-                <li><a href="/commands/window">Window</a></li>
-                <li><a href="/commands/viewport">Viewport</a></li>
-                <li><a href="/commands/location">Location</a></li>
-                <li><a href="/commands/navigation">Navigation</a></li>
-                <li><a href="/commands/assertions">Assertions</a></li>
-                <li><a href="/commands/misc">Misc</a></li>
-                <li><a href="/commands/connectors">Connectors</a></li>
-                <li><a href="/commands/aliasing">Aliasing</a></li>
-                <li><a href="/commands/waiting">Waiting</a></li>
-                <li>
-                  <a href="/commands/network-requests">Network Requests</a>
-                </li>
-                <li><a href="/commands/files">Files</a></li>
-                <li><a href="/commands/local-storage">Local Storage</a></li>
-                <li><a href="/commands/cookies">Cookies</a></li>
-                <li>
-                  <a href="/commands/spies-stubs-clocks"
-                    >Spies, Stubs &amp; Clocks</a
-                  >
-                </li>
+                <li data-test="Querying" class="active"><a href="/commands/querying">Querying</a></li>
+                <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+                <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+                <li data-test="Window"><a href="/commands/window">Window</a></li>
+                <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+                <li data-test="Location"><a href="/commands/location">Location</a></li>
+                <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+                <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+                <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+                <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+                <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+                <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+                <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+                <li data-test="Files"><a href="/commands/files">Files</a></li>
+                <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+                <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+                <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
               </ul>
             </li>
             <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/spies-stubs-clocks.html
+++ b/app/commands/spies-stubs-clocks.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/fixtures">Fixtures</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li class="active"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks" class="active"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/traversal.html
+++ b/app/commands/traversal.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li class="active"><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal" class="active"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/viewport.html
+++ b/app/commands/viewport.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li class="active"><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport" class="active"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/waiting.html
+++ b/app/commands/waiting.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li class="active"><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting" class="active"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/commands/window.html
+++ b/app/commands/window.html
@@ -31,23 +31,23 @@
           <li class="active" class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li class="active"><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li  data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window" class="active"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/cypress-api.html
+++ b/app/cypress-api.html
@@ -31,23 +31,23 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/index.html
+++ b/app/index.html
@@ -32,22 +32,22 @@
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
               <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li><a href="/utilities">Utilities</a></li>

--- a/app/todo.html
+++ b/app/todo.html
@@ -32,23 +32,23 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="/commands/querying">Querying</a></li>
-                <li><a href="/commands/traversal">Traversal</a></li>
-                <li><a href="/commands/actions">Actions</a></li>
-                <li><a href="/commands/window">Window</a></li>
-                <li><a href="/commands/viewport">Viewport</a></li>
-                <li><a href="/commands/location">Location</a></li>
-                <li><a href="/commands/navigation">Navigation</a></li>
-                <li><a href="/commands/assertions">Assertions</a></li>
-                <li><a href="/commands/misc">Misc</a></li>
-                <li><a href="/commands/connectors">Connectors</a></li>
-                <li><a href="/commands/aliasing">Aliasing</a></li>
-                <li><a href="/commands/waiting">Waiting</a></li>
-                <li><a href="/commands/network-requests">Network Requests</a></li>
-                <li><a href="/commands/files">Files</a></li>
-                <li><a href="/commands/local-storage">Local Storage</a></li>
-                <li><a href="/commands/cookies">Cookies</a></li>
-                <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+                <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+                <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+                <li data-test="Actions"><a href="/commands/actions">Actions</a></li>
+                <li data-test="Window"><a href="/commands/window">Window</a></li>
+                <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+                <li data-test="Location"><a href="/commands/location">Location</a></li>
+                <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+                <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+                <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+                <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+                <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+                <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+                <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+                <li data-test="Files"><a href="/commands/files">Files</a></li>
+                <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+                <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+                <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
               </ul>
             </li>
             <li><a href="/utilities">Utilities</a></li>

--- a/app/utilities.html
+++ b/app/utilities.html
@@ -31,23 +31,23 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">Commands <span class="caret"></span></a>
             <ul class="dropdown-menu">
-              <li><a href="/commands/querying">Querying</a></li>
-              <li><a href="/commands/traversal">Traversal</a></li>
-              <li><a href="/commands/actions">Actions</a></li>
-              <li><a href="/commands/window">Window</a></li>
-              <li><a href="/commands/viewport">Viewport</a></li>
-              <li><a href="/commands/location">Location</a></li>
-              <li><a href="/commands/navigation">Navigation</a></li>
-              <li><a href="/commands/assertions">Assertions</a></li>
-              <li><a href="/commands/misc">Misc</a></li>
-              <li><a href="/commands/connectors">Connectors</a></li>
-              <li><a href="/commands/aliasing">Aliasing</a></li>
-              <li><a href="/commands/waiting">Waiting</a></li>
-              <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/files">Files</a></li>
-              <li><a href="/commands/local-storage">Local Storage</a></li>
-              <li><a href="/commands/cookies">Cookies</a></li>
-              <li><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
+              <li data-test="Querying"><a href="/commands/querying">Querying</a></li>
+              <li data-test="Traversal"><a href="/commands/traversal">Traversal</a></li>
+              <li data-test="Actions"><a href="/commands/actions">Actions</a></li>
+              <li data-test="Window"><a href="/commands/window">Window</a></li>
+              <li data-test="Viewport"><a href="/commands/viewport">Viewport</a></li>
+              <li data-test="Location"><a href="/commands/location">Location</a></li>
+              <li data-test="Navigation"><a href="/commands/navigation">Navigation</a></li>
+              <li data-test="Assertions"><a href="/commands/assertions">Assertions</a></li>
+              <li data-test="Misc"><a href="/commands/misc">Misc</a></li>
+              <li data-test="Connectors"><a href="/commands/connectors">Connectors</a></li>
+              <li data-test="Aliasing"><a href="/commands/aliasing">Aliasing</a></li>
+              <li data-test="Waiting"><a href="/commands/waiting">Waiting</a></li>
+              <li data-test="NetworkRequests"><a href="/commands/network-requests">Network Requests</a></li>
+              <li data-test="Files"><a href="/commands/files">Files</a></li>
+              <li data-test="LocalStorage"><a href="/commands/local-storage">Local Storage</a></li>
+              <li data-test="Cookies"><a href="/commands/cookies">Cookies</a></li>
+              <li data-test="SpiesStubsClocks"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>
             </ul>
           </li>
           <li class="active"><a href="/utilities">Utilities</a></li>


### PR DESCRIPTION
added locators to drop down menu items:
data-test="Querying"
data-test="Traversal"
data-test="Actions"
data-test="Window"
data-test="Viewport"
data-test="Location"
data-test="Navigation"
data-test="Assertions"
data-test="Misc"
data-test="Connectors"
data-test="Aliasing"
data-test="Waiting"
data-test="NetworkRequests"
data-test="Files"
data-test="LocalStorage"
data-test="Cookies"
data-test="SpiesStubsClocks" 